### PR TITLE
fixed typo: spam -> span

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -77,7 +77,7 @@ ArchiveURL      := Concatenation( ~.SourceRepository.URL,
 ArchiveFormats := ".tar.gz",
 
 AbstractHTML := 
-  "The <span class=\"pkgname\">GBNP</spam> package provides algorithms for \
+  "The <span class=\"pkgname\">GBNP</span> package provides algorithms for \
    computing Grobner bases of noncommutative polynomials with coefficients \
    from a field implemented in <span class=\"pkgname\">GAP</span> and with \
    respect to the \"total degree first then lexicographical\" ordering. \


### PR DESCRIPTION
Why has the version number been set at 1.0dev when the released version is 1.3?  Expecting 1.3dev.