### PR TITLE
Test20

### DIFF
--- a/tst/test20.tst
+++ b/tst/test20.tst
@@ -60,6 +60,7 @@ gap> # <L>
 gap> twosidrels:=[a^4-e,b^2-e,(a*b)^2-e];;
 gap> D:=A^2;;
 gap> y:=GeneratorsOfLeftModule(D);;
+gap> GBNP.SetOption("pg", Length(y));
 gap> modrels:=[y[1]*b-y[1], y[2]*b-y[2], y[1]+y[1]*a*(e+a+b) -y[2]-y[2]*a*(e+a+b)];;
 gap> # </L>
 gap> 

--- a/tst/test20.tst
+++ b/tst/test20.tst
@@ -60,6 +60,14 @@ gap> # <L>
 gap> twosidrels:=[a^4-e,b^2-e,(a*b)^2-e];;
 gap> D:=A^2;;
 gap> y:=GeneratorsOfLeftModule(D);;
+gap> #
+gap> # (Sept. 2023) The following GBNP.SetOption command has been added
+gap> # because the PrintNPList(modrelsNP); command below was throwing 
+gap> # an error, printing [ b - 1 ] instead of [ b - 1, 0]. 
+gap> # This was due to GAP not knowing that the dimension is 2. 
+gap> # The fix is labelled 'temporary' because SetOption commands 
+gap> # ought not to be used in a test situation.
+gap> #
 gap> GBNP.SetOption("pg", Length(y));
 gap> modrels:=[y[1]*b-y[1], y[2]*b-y[2], y[1]+y[1]*a*(e+a+b) -y[2]-y[2]*a*(e+a+b)];;
 gap> # </L>


### PR DESCRIPTION
The problem which arises if test20 is run after test19 (say) is that GBNP does not know that the dimension of the module is 2. Indeed, the pg option may well be set to 1. And it happens that the first vector to be printed is [b-1,0], with zero in the second component. So, not knowing that the dimension should be 2, just [b-1] is printed. The second vector is [0,b-1], so the dimension is then set to 2 and all is well from then on. So the temporary fix is to add: GBNP.SetOption("pg", Length(y)); to test20.tst, which fixes the dimension. Ideally users should not be making calls to SetOption, which is why I have called this a "temporary fix". 