### PR TITLE
Add GBNP.Config commands to tests so they can be run in any order

### DIFF
--- a/tst/test02.tst
+++ b/tst/test02.tst
@@ -85,6 +85,8 @@ gap>
 gap> I := Concatenation([s1,s2],MkTrLst(n));;
 gap> # </L>
 gap> 
+gap> # add the next command in case other tests have changed the alphabet:
+gap> GBNP.ConfigPrint("a","b","c");
 gap> # To give an impression, we print the first 20 entries of this list:
 gap> # <L>
 gap> PrintNPList(I{[1..20]});

--- a/tst/test06.tst
+++ b/tst/test06.tst
@@ -110,6 +110,8 @@ gap> for i in [1..5] do
 > od;
 gap> # </L>
 gap> 
+gap> # add the next command in case other tests have changed the alphabet:
+gap> GBNP.ConfigPrint("a","b","c","d","e","f");
 gap> # The relations can be shown with <Ref Func="PrintNPList" Style="Text"/>:
 gap> 
 gap> # <L>

--- a/tst/test10.tst
+++ b/tst/test10.tst
@@ -101,6 +101,8 @@ gap> GB := SGrobner(KI);;
 #I  End of phase II
 #I  End of phase III
 #I  End of phase IV
+gap> # add the next command in case other tests have changed the alphabet:
+gap> GBNP.ConfigPrint("a","b","c","d","e","f","g");
 gap> PrintNPList(GB);
  a 
  b 

--- a/tst/test12.tst
+++ b/tst/test12.tst
@@ -59,6 +59,8 @@ gap> # function <Ref Func="GP2NPList" Style="Text"/> and can be subsequently
 gap> # displayed with <Ref Func="PrintNPList" Style="Text"/>.
 gap> 
 gap> # <L>
+gap> # add the next command in case other tests have changed the alphabet:
+gap> GBNP.ConfigPrint("a","b","c");
 gap> uerelsNP:=GP2NPList(uerels);;
 gap> PrintNPList(uerelsNP);
  ba - ab + c 

--- a/tst/test16.tst
+++ b/tst/test16.tst
@@ -107,6 +107,8 @@ gap> # </L>
 gap> 
 gap> # The relations can be shown with <Ref Func="PrintNPList" Style="Text"/>:
 gap> 
+gap> # add the next command in case other tests have changed the alphabet:
+gap> GBNP.ConfigPrint("a","b","c","d","e","f");
 gap> # <L>
 gap> PrintNPList(KI);
  ea 

--- a/tst/test24.tst
+++ b/tst/test24.tst
@@ -53,6 +53,8 @@ gap> KI := [ [[[2,1],[1,1,2]],[1,-1]],
 >         [[[3,6], []],[1,-1]],
 >         [[[6,3], []],[1,-1]],
 >       ];;
+gap> # add the next command in case other tests have changed the alphabet:
+gap> GBNP.ConfigPrint("a","b","c","d","e","f");
 gap> PrintNPList(KI);
  ba - a^2b 
  cb - b^2c 

--- a/tst/test25.tst
+++ b/tst/test25.tst
@@ -103,6 +103,8 @@ gap> # using <Ref Func="MatricesQA" Style="Text"/>
 gap> # and determine the minimal polynomial of the sum of the three matrices.
 gap> 
 gap> # <L>
+gap> # add the next command in case other tests have changed the alphabet:
+gap> GBNP.ConfigPrint("x");
 gap> B := BaseQA(GB,3,0);;
 gap> M := MatricesQA(3,B,GB);;
 gap> f := MinimalPolynomial(Rationals,M[1]+M[2]+M[3]);


### PR DESCRIPTION
The default letters to print with are "a", "b", "c", ...  Some tests use other alphabets, and so contain a GBNP.Config command requiring (say) "x", "y", "z".  If a test requiring the default letters is run after this then x,y,z are used and an error results.  The 7 tests requiring the default alphabet are test02, test06, test10, test12, test16, test24 and test25.  The PR adds the appropriate GBNP.Config( "a", "b", ...) command to these 7 tests.  Now tests can be run in any order. 