### PR TITLE
rearranged section 5.4 of the manual

### DIFF
--- a/doc/nmo.xml
+++ b/doc/nmo.xml
@@ -25,7 +25,8 @@
 <Section Label="sec-nmo-intro">
 <Heading>Introduction</Heading>
 
-Up until September 2023 the <Package>NMO</Package> manual was provided by 
+Up until September 2023 the manual for Randall Cone's package 
+<Package>NMO</Package> was provided by 
 <Package>GBNP</Package> as a separate <File>manual.pdf</File>. 
 The <Package>NMO</Package> manual now forms this chapter 
 in the <Package>GBNP</Package> manual. 
@@ -421,13 +422,12 @@ gap> NP2GPList( gb4, A4 );
 </Section>
 
 
-<Section><Heading>Orderings</Heading>
-This section describes the current orderings built into the <Package>GAP</Package>
-package <Package>NMO</Package>, and describes some of the internals of the
-machinery involved.
+<Section><Heading>Orderings - Internals</Heading>
+This section, and the following two, describe the current orderings 
+built into the <Package>GAP</Package> package <Package>NMO</Package>, 
+and describes some of the internals of the machinery involved.
 <P/>
 
-<Subsection><Heading>Internals</Heading>
 The orderings portion of <Package>NMO</Package> is divided codewise into the files
 <C>ncordmachine.gd, ncordmachine.gi</C> and <C>ncorderings.gd, ncorderings.gi</C>.
 The former file pair contains code to set up the machinery to
@@ -491,47 +491,44 @@ it is utilized in the creation of the ordering:
 gap> lexord2 := NCMonomialLeftLexicographicOrdering(A,[2,3,1]);
 NCMonomialLeftLexicographicOrdering([ (1)*b, (1)*c, (1)*a ])
 </Example>
-</Subsection>
+
+<#Include Label="InstallNoncommutativeMonomialOrdering">
+<#Include Label="IsNoncommutativeMonomialOrdering">
+<#Include Label="LtFunctionListRep">
+<#Include Label="NextOrdering">
+<#Include Label="ParentAlgebra">
+<#Include Label="LexicographicTable">
+<#Include Label="LexicographicIndexTable">
+<#Include Label="LexicographicPermutation">
+<#Include Label="AuxilliaryTable">
+<#Include Label="OrderingLtGtFunctions">
+</Section>
 
 
-<ManSection><Heading>Internal Routines</Heading>
-  <#Include Label="InstallNoncommutativeMonomialOrdering">
-  <#Include Label="IsNoncommutativeMonomialOrdering">
-  <#Include Label="LtFunctionListRep">
-  <#Include Label="NextOrdering">
-  <#Include Label="ParentAlgebra">
-  <#Include Label="LexicographicTable">
-  <#Include Label="LexicographicIndexTable">
-  <#Include Label="LexicographicPermutation">
-  <#Include Label="AuxilliaryTable">
-  <#Include Label="OrderingLtGtFunctions">
-</ManSection>
+<Section><Heading>Provided Orderings</Heading>
+<#Include Label="NCMonomialLeftLengthLexicographicOrdering">
+<#Include Label="NCMonomialLengthOrdering">
+<#Include Label="NCMonomialLeftLexicographicOrdering">
+<#Include Label="NCMonomialCommutativeLexicographicOrdering">
+<#Include Label="NCMonomialWeightOrdering">
+</Section>
 
-<ManSection><Heading>Provided Orderings</Heading>
-  <#Include Label="NCMonomialLeftLengthLexicographicOrdering">
-  <#Include Label="NCMonomialLengthOrdering">
-  <#Include Label="NCMonomialLeftLexicographicOrdering">
-  <#Include Label="NCMonomialCommutativeLexicographicOrdering">
-  <#Include Label="NCMonomialWeightOrdering">
-</ManSection>
 
-<Subsection><Heading>Externals</Heading>
+<Section><Heading>Orderings - Externals</Heading>
 
 All user-level interface routines in the descriptions following
- allow for the comparison
-of not only monomials from a given algebra with respect to a given ordering, but
+allow for the comparisonof not only monomials from a given algebra 
+with respect to a given ordering, but
 also compare general elements from an algebra by comparing their
 leading terms (again, with respect to the given ordering).
 These routines are located in the files
 <C>ncinterface.gd</C> and <C>ncinterface.gi</C>.
-</Subsection>
+<P/>
 
-<ManSection><Heading>External Routines</Heading>
-  <#Include Label="NCLessThanByOrdering">
-  <#Include Label="NCGreaterThanByOrdering">
-  <#Include Label="NCEquivalentByOrdering">
-  <#Include Label="NCSortNP">
-</ManSection>
+<#Include Label="NCLessThanByOrdering">
+<#Include Label="NCGreaterThanByOrdering">
+<#Include Label="NCEquivalentByOrdering">
+<#Include Label="NCSortNP">
 
 <Subsection><Heading>Flexibility vs. Efficiency</Heading>
 We recall that <C>InstallNoncommutativeMonomialOrdering</C> completes

--- a/lib/nmo/ncinterface.gd
+++ b/lib/nmo/ncinterface.gd
@@ -13,6 +13,7 @@
 #############################################################################
 ##
 ##  <#GAPDoc Label="NCLessThanByOrdering">
+##  <ManSection>
 ##  <Oper Name="NCLessThanByOrdering"
 ##        Arg="&lt;NoncommutativeMonomialOrdering>, &lt;a>, &lt;b>"/>
 ##  
@@ -24,7 +25,7 @@
 ##  determined by <C>&lt;NoncommutativeMonomialOrdering></C>.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareOperation("NCLessThanByOrdering",
@@ -37,6 +38,7 @@ DeclareOperation("NCLessThanByOrdering",
 #############################################################################
 ##
 ##  <#GAPDoc Label="NCGreaterThanByOrdering">
+##  <ManSection>
 ##  <Oper Name="NCGreaterThanByOrdering"
 ##        Arg="&lt;NoncommutativeMonomialOrdering>, &lt;a>, &lt;b>"/>
 ##  
@@ -49,7 +51,7 @@ DeclareOperation("NCLessThanByOrdering",
 ##  <P/>
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareOperation("NCGreaterThanByOrdering",
@@ -61,6 +63,7 @@ DeclareOperation("NCGreaterThanByOrdering",
 #############################################################################
 ##
 ##  <#GAPDoc Label="NCEquivalentByOrdering">
+##  <ManSection>
 ##  <Oper Name="NCEquivalentByOrdering"
 ##        Arg="&lt;NoncommutativeMonomialOrdering>, &lt;a>, &lt;b>"/>
 ##  
@@ -113,7 +116,7 @@ DeclareOperation("NCGreaterThanByOrdering",
 ##  <P/>
 ##
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareOperation("NCEquivalentByOrdering",
@@ -126,6 +129,7 @@ DeclareOperation("NCEquivalentByOrdering",
 #############################################################################
 ##
 ##  <#GAPDoc Label="NCSortNP">
+##  <ManSection>
 ##  <Oper Name="NCSortNP"
 ##        Arg="&lt;NoncommutativeMonomialOrdering>, &lt;list>, &lt;function>"/>
 ##  
@@ -139,7 +143,7 @@ DeclareOperation("NCEquivalentByOrdering",
 ##  from <Cite Key="gN02"/>.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareOperation("NCSortNP",

--- a/lib/nmo/ncorderings.gd
+++ b/lib/nmo/ncorderings.gd
@@ -11,6 +11,7 @@
 #############################################################################
 ##
 ##  <#GAPDoc Label="NCMonomialLeftLengthLexicographicOrdering">
+##  <ManSection>
 ##  <Func Name="NCMonomialLeftLengthLexicographicOrdering"
 ##        Arg="&lt;algebra>, &lt;list>"/>
 ##
@@ -27,7 +28,7 @@
 ##  Note: the synonym <C>NCMonomialLeftLengthLexOrdering</C> may also be used.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction("NCMonomialLeftLengthLexicographicOrdering");
@@ -38,6 +39,7 @@ DeclareSynonym("NCMonomialLeftLengthLexOrdering",
 #############################################################################
 ##
 ##  <#GAPDoc Label="NCMonomialLengthOrdering">
+##  <ManSection>
 ##  <Func Name="NCMonomialLengthOrdering"
 ##        Arg="&lt;algebra>"/>
 ##
@@ -48,7 +50,7 @@ DeclareSynonym("NCMonomialLeftLengthLexOrdering",
 ##  are compared using this ordering.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction("NCMonomialLengthOrdering");
@@ -57,6 +59,7 @@ DeclareGlobalFunction("NCMonomialLengthOrdering");
 #############################################################################
 ##
 ##  <#GAPDoc Label="NCMonomialLeftLexicographicOrdering">
+##  <ManSection>
 ##  <Func Name="NCMonomialLeftLexicographicOrdering"
 ##        Arg="&lt;algebra>, &lt;list>"/>
 ##
@@ -67,7 +70,7 @@ DeclareGlobalFunction("NCMonomialLengthOrdering");
 ##  left-lexicographic ordering object.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction("NCMonomialLeftLexicographicOrdering");
@@ -76,6 +79,7 @@ DeclareGlobalFunction("NCMonomialLeftLexicographicOrdering");
 #############################################################################
 ##
 ##  <#GAPDoc Label="NCMonomialCommutativeLexicographicOrdering">
+##  <ManSection>
 ##  <Func Name="NCMonomialCommutativeLexicographicOrdering"
 ##        Arg="&lt;algebra>, &lt;list>"/>
 ##
@@ -88,7 +92,7 @@ DeclareGlobalFunction("NCMonomialLeftLexicographicOrdering");
 ##  using their respective commutative analogues.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction("NCMonomialCommutativeLexicographicOrdering");
@@ -97,6 +101,7 @@ DeclareGlobalFunction("NCMonomialCommutativeLexicographicOrdering");
 #############################################################################
 ##
 ##  <#GAPDoc Label="NCMonomialWeightOrdering">
+##  <ManSection>
 ##  <Func Name="NCMonomialWeightOrdering"
 ##        Arg="&lt;algebra>, &lt;list>, &lt;list2>"/>
 ##
@@ -108,7 +113,7 @@ DeclareGlobalFunction("NCMonomialCommutativeLexicographicOrdering");
 ##  weight ordering object.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction("NCMonomialWeightOrdering");

--- a/lib/nmo/ncordmachine.gd
+++ b/lib/nmo/ncordmachine.gd
@@ -11,6 +11,7 @@
 #############################################################################
 ##
 ##  <#GAPDoc Label="IsNoncommutativeMonomialOrdering">
+##  <ManSection>
 ##  <Filt Name="IsNoncommutativeMonomialOrdering"
 ##        Arg="&lt;obj>"
 ##        Type="Category"/>
@@ -21,7 +22,7 @@
 ##  orderings are of this category. 
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareCategory("IsNoncommutativeMonomialOrdering",IsObject);
@@ -30,6 +31,7 @@ DeclareCategory("IsNoncommutativeMonomialOrdering",IsObject);
 #############################################################################
 ##
 ##  <#GAPDoc Label="LtFunctionListRep">
+##  <ManSection>
 ##  <Attr Name="LtFunctionListRep"
 ##        Arg="&lt;NoncommutativeMonomialOrdering>"/>
 ##  
@@ -41,7 +43,7 @@ DeclareCategory("IsNoncommutativeMonomialOrdering",IsObject);
 ##  algebra.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareAttribute("LtFunctionListRep", IsNoncommutativeMonomialOrdering);
@@ -50,6 +52,7 @@ DeclareAttribute("LtFunctionListRep", IsNoncommutativeMonomialOrdering);
 #############################################################################
 ##
 ##  <#GAPDoc Label="NextOrdering">
+##  <ManSection>
 ##  <Attr Name="NextOrdering"
 ##        Arg="&lt;NoncommutativeMonomialOrdering>"/>
 ##  
@@ -59,7 +62,7 @@ DeclareAttribute("LtFunctionListRep", IsNoncommutativeMonomialOrdering);
 ##  has been made with a <C>HasNextOrdering</C> call.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareAttribute("NextOrdering",IsNoncommutativeMonomialOrdering);
@@ -68,6 +71,7 @@ DeclareAttribute("NextOrdering",IsNoncommutativeMonomialOrdering);
 #############################################################################
 ##
 ##  <#GAPDoc Label="ParentAlgebra">
+##  <ManSection>
 ##  <Attr Name="ParentAlgebra"
 ##        Arg="&lt;NoncommutativeMonomialOrdering>"/>
 ##  
@@ -76,7 +80,7 @@ DeclareAttribute("NextOrdering",IsNoncommutativeMonomialOrdering);
 ##  ordering.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareAttribute("ParentAlgebra", IsNoncommutativeMonomialOrdering );
@@ -85,6 +89,7 @@ DeclareAttribute("ParentAlgebra", IsNoncommutativeMonomialOrdering );
 #############################################################################
 ##
 ##  <#GAPDoc Label="LexicographicTable">
+##  <ManSection>
 ##  <Attr Name="LexicographicTable"
 ##        Arg="&lt;NoncommutativeMonomialOrdering>"/>
 ##  
@@ -93,7 +98,7 @@ DeclareAttribute("ParentAlgebra", IsNoncommutativeMonomialOrdering );
 ##   as specified in the creation of the given ordering.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareAttribute("LexicographicTable", IsNoncommutativeMonomialOrdering);
@@ -102,6 +107,7 @@ DeclareAttribute("LexicographicTable", IsNoncommutativeMonomialOrdering);
 #############################################################################
 ##
 ##  <#GAPDoc Label="LexicographicIndexTable">
+##  <ManSection>
 ##  <Attr Name="LexicographicIndexTable"
 ##        Arg="&lt;NoncommutativeMonomialOrdering>"/>
 ##  
@@ -131,7 +137,7 @@ DeclareAttribute("LexicographicTable", IsNoncommutativeMonomialOrdering);
 ##  and <M>d</M> the second least in order.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareAttribute("LexicographicIndexTable", IsNoncommutativeMonomialOrdering);
@@ -140,6 +146,7 @@ DeclareAttribute("LexicographicIndexTable", IsNoncommutativeMonomialOrdering);
 #############################################################################
 ##
 ##  <#GAPDoc Label="LexicographicPermutation">
+##  <ManSection>
 ##  <Attr Name="LexicographicPermutation"
 ##        Arg="&lt;NoncommutativeMonomialOrdering>"/>
 ##  
@@ -150,7 +157,7 @@ DeclareAttribute("LexicographicIndexTable", IsNoncommutativeMonomialOrdering);
 ##  by the <Package>NMO</Package> built-in ordering <C>NCMonomialLLLTestOrdering</C>.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareAttribute("LexicographicPermutation", IsNoncommutativeMonomialOrdering);
@@ -159,6 +166,7 @@ DeclareAttribute("LexicographicPermutation", IsNoncommutativeMonomialOrdering);
 #############################################################################
 ##
 ##  <#GAPDoc Label="AuxilliaryTable">
+##  <ManSection>
 ##  <Attr Name="AuxilliaryTable"
 ##        Arg="&lt;NoncommutativeMonomialOrdering>"/>
 ##  
@@ -167,7 +175,7 @@ DeclareAttribute("LexicographicPermutation", IsNoncommutativeMonomialOrdering);
 ##  for such things as weight vectors, etc.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareAttribute("AuxilliaryTable", IsNoncommutativeMonomialOrdering);
@@ -191,6 +199,7 @@ BindGlobal("NoncommutativeMonomialOrderingsFamily",
 #############################################################################
 ##
 ##  <#GAPDoc Label="InstallNoncommutativeMonomialOrdering">
+##  <ManSection>
 ##  <Func Name="InstallNoncommutativeMonomialOrdering"
 ##        Arg="&lt;string>, &lt;function>, &lt;function2>"/>
 ##
@@ -238,7 +247,7 @@ BindGlobal("NoncommutativeMonomialOrderingsFamily",
 ##    <P/>
 ##    
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction("InstallNoncommutativeMonomialOrdering");
@@ -247,6 +256,7 @@ DeclareGlobalFunction("InstallNoncommutativeMonomialOrdering");
 #############################################################################
 ##
 ##  <#GAPDoc Label="OrderingLtGtFunctions">
+##  <ManSection>
 ##  <Oper Name="OrderingLtFunctionListRep"
 ##        Arg="&lt;NoncommutativeMonomialOrdering>"/>
 ##  
@@ -265,7 +275,7 @@ DeclareGlobalFunction("InstallNoncommutativeMonomialOrdering");
 ##  These functions are not typically accessed by the user.
 ##  <P/>
 ##  </Description>
-##
+##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareOperation("OrderingLtFunctionListRep",


### PR DESCRIPTION
The layout on pages 59-61 of the manual could be a lot clearer.  This has arisen when converting the NMO manual into a chapter of the GBNP manual.  Problem solved by converting 5.4.3 into a new section 5.5 and 5.4.4 into a new section 5.6.  Then the various NCMonomial... functions can become ManSections.